### PR TITLE
Fix social media icon links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -146,9 +146,9 @@ weight = 13
     [params.communityStatus]
     [[params.communityStatus.item]]
     social = [
-            ["icon-reddit", "https://twitter.com/jamesl22"],
-            ["icon-twitter", "https://github.com/metalicjames/"],
-            ["icon-discord", "https://github.com/metalicjames/"]
+            ["icon-reddit", "https://reddit.com/r/vertcoin"],
+            ["icon-twitter", "https://twitter.com/vertcoin"],
+            ["icon-discord", "https://discord.gg/vertcoin"]
           ]
 
 


### PR DESCRIPTION
The social media icons in the "Vibrant Community's" section on the homepage link to the wrong social media platforms or James' personal pages.

This PR fixes the issue.
