### PR TITLE
Fix Safari Bug - Vertcoin Logo

### DIFF
--- a/themes/elate/static/css/style.css
+++ b/themes/elate/static/css/style.css
@@ -1827,7 +1827,7 @@ h4 svg {
 
 .navbar-brand svg {
   width: 171px;
-  height: auto;
+  height: 34px;
 }
 
 @media screen and (max-width: 767px) {


### PR DESCRIPTION
Auto height was causing problems on safari, fixed using specified height