### PR TITLE
Move Webfont to Footer

### DIFF
--- a/themes/elate/layouts/partials/head.html
+++ b/themes/elate/layouts/partials/head.html
@@ -96,5 +96,4 @@
 
 
 
-    <!-- Gotham Web Font / Cloud Typography -->
-    <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/6577236/7675792/css/fonts.css" />
+    


### PR DESCRIPTION
Move Webfont from Head to Footer due to page load speed.

Pauses rendering until asset is retrieved.