### PR TITLE
Correct spelling in 'socialContractPictureCaption_0_title' (en.toml)

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -213,7 +213,7 @@
 # Social Contract Picture
 
 [socialContractPictureCaption_0_title]
-    other = "We will create the most balanced system, free from coporate interests. A monetary system for the people of the world to be proud of."
+    other = "We will create the most balanced system, free from corporate interests. A monetary system for the people of the world to be proud of."
 
 
 # No Premine ICO AirDrop


### PR DESCRIPTION
ping @CryptoPlankton

----

The word "*corporate*" was written wrong in [`socialContractPictureCaption_0_title`](https://github.com/vertcoin-project/vertcoin-website/blob/master/i18n/en.toml#L216) in the `en.toml` file.

--[**Suriyaa Sundararuban**](https://suriyaa.tk/) <a href="https://github.com/SuriyaaKudoIsc"><img src="https://assets-cdn.github.com/images/icons/emoji/octocat.png" alt="GitHub Developer" width="18" height="18" /></a> <a href="https://vertcoin.org/team/"><img src="https://cdn.discordapp.com/emojis/430323443918176256.png" alt="Future Official Vertcoin Developer?" width="20" height="20" /></a> (***Donate some VTC:*** `3GzoCsknkwM7ZSqKYYsUaz7wCMnFbCN6uh`)

*(From pull request #144. I closed the old one because I made a Git merge and push mistake.)*